### PR TITLE
Fix saas mixed-decls warning

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -692,6 +692,15 @@ $btn-mb: 0.5rem;
     var(--sidebar-bg-image);
   border-right: 1px solid var(--sidebar-border-color);
 
+  /* Hide scrollbar for IE, Edge and Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
   &::before {
     content: "";
     position: absolute;
@@ -704,15 +713,6 @@ $btn-mb: 0.5rem;
   > * {
     position: relative;
     z-index: 1;
-  }
-
-  /* Hide scrollbar for IE, Edge and Firefox */
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-
-  /* Hide scrollbar for Chrome, Safari and Opera */
-  &::-webkit-scrollbar {
-    display: none;
   }
 
   %sidebar-link-hover {


### PR DESCRIPTION
## Summary
Reorder CSS declarations in sidebar to fix Dart Sass mixed-decls warning.

## Changes
Moved scrollbar-hiding properties before nested rules in `#sidebar`.

## Why
Dart Sass 3.0.0 will require declarations to appear before nested rules.
